### PR TITLE
Curate portfolio page with richer LinkedIn profile and project sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ If `title` is omitted, the first markdown heading is used as the title.
 
 Update `src/config.ts`:
 
-- `githubUsername`: GitHub user for project auto-discovery.
-- `linkedin.url`: Your public LinkedIn profile URL.
-- `linkedin.headline`, `linkedin.summary`, `location`, `tagline`: Profile intro shown on the portfolio page.
-- `interests`: Topic tags shown under your intro.
-- `featuredRepoNames`: Repository names to pin into the Featured section.
+- `name`, `linkedin.url`, `linkedin.headline`, `linkedin.summary`, `location`, `tagline` for your intro.
+- `experience` and `education` arrays to keep key profile history up to date.
+- `publications` to highlight papers/articles with links.
+- `githubUsername` and `featuredRepoNames` for automatic GitHub project curation.
+- `interests` tags for quick skill/context chips.
 
-The portfolio page automatically sections projects into **Featured**, **Top starred**, and **Recently updated**.
+The portfolio page includes manual curation blocks (publication, experience, education) plus automatic GitHub sections (**Featured**, **Top starred**, **Recently updated**).

--- a/README.md
+++ b/README.md
@@ -1,3 +1,31 @@
-# Anant's Repository of Things
+# Anant's Blog & Portfolio
 
-This is a repo to hold all the weird side projects I've been up to!
+This site supports a markdown-driven blog homepage and a curated portfolio tab that auto-loads repositories from GitHub.
+
+## Add new blog posts
+
+1. Create a new file in `src/content`, for example `src/content/my-new-post.md`.
+2. Add optional frontmatter:
+
+```md
+---
+title: My New Post
+date: 2026-02-12
+---
+
+# Markdown content goes here
+```
+
+If `title` is omitted, the first markdown heading is used as the title.
+
+## Curate your portfolio and LinkedIn profile
+
+Update `src/config.ts`:
+
+- `githubUsername`: GitHub user for project auto-discovery.
+- `linkedin.url`: Your public LinkedIn profile URL.
+- `linkedin.headline`, `linkedin.summary`, `location`, `tagline`: Profile intro shown on the portfolio page.
+- `interests`: Topic tags shown under your intro.
+- `featuredRepoNames`: Repository names to pin into the Featured section.
+
+The portfolio page automatically sections projects into **Featured**, **Top starred**, and **Recently updated**.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,15 +1,47 @@
+import { useState } from 'react';
 import Blog from './components/Blog';
+import Portfolio from './components/Portfolio';
+
+type Tab = 'blog' | 'portfolio';
 
 function App() {
+  const [activeTab, setActiveTab] = useState<Tab>('blog');
+
   return (
-    <div className="h-screen flex items-center justify-center bg-white dark:bg-gray-900 text-black dark:text-white">
-      <div className="max-w-2xl p-4 text-center">
-        <h1 className="text-3xl font-bold mb-4">Anant's Repository of Things</h1>
-          <Blog />
+    <div className="min-h-screen bg-gray-50 px-4 py-8 text-black dark:bg-gray-900 dark:text-white">
+      <div className="mx-auto w-full max-w-4xl space-y-6">
+        <header className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+          <h1 className="text-3xl font-bold">Anant&apos;s Blog</h1>
+          <nav className="mt-4 flex gap-2">
+            <button
+              type="button"
+              onClick={() => setActiveTab('blog')}
+              className={`rounded px-4 py-2 text-sm font-semibold transition ${
+                activeTab === 'blog'
+                  ? 'bg-blue-600 text-white'
+                  : 'bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600'
+              }`}
+            >
+              Blog
+            </button>
+            <button
+              type="button"
+              onClick={() => setActiveTab('portfolio')}
+              className={`rounded px-4 py-2 text-sm font-semibold transition ${
+                activeTab === 'portfolio'
+                  ? 'bg-blue-600 text-white'
+                  : 'bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600'
+              }`}
+            >
+              Portfolio
+            </button>
+          </nav>
+        </header>
+
+        <main>{activeTab === 'blog' ? <Blog /> : <Portfolio />}</main>
       </div>
     </div>
   );
-};
+}
 
-
-export default App
+export default App;

--- a/src/components/BlogPostCard.tsx
+++ b/src/components/BlogPostCard.tsx
@@ -1,18 +1,24 @@
 import React from 'react';
 import Markdown from 'react-markdown';
-import remarkGfm from 'remark-gfm'
+import remarkGfm from 'remark-gfm';
 
 interface BlogPostCardProps {
   title: string;
   content: string;
+  date?: string;
 }
 
-const BlogPostCard: React.FC<BlogPostCardProps> = ({ title, content }) => {
+const BlogPostCard: React.FC<BlogPostCardProps> = ({ title, content, date }) => {
   return (
-    <div className="border rounded-lg shadow-md p-4 mb-4 bg-white dark:bg-gray-800">
-      <h2 className="text-xl font-bold mb-2">{title}</h2>
-      <Markdown className="prose" remarkPlugins={[remarkGfm]}>{content}</Markdown>
-    </div>
+    <article className="rounded-lg border border-gray-200 bg-white p-6 text-left shadow-sm dark:border-gray-700 dark:bg-gray-800">
+      <h2 className="mb-1 text-2xl font-bold">{title}</h2>
+      {date ? (
+        <p className="mb-4 text-sm text-gray-500 dark:text-gray-400">{date}</p>
+      ) : null}
+      <Markdown className="prose max-w-none dark:prose-invert" remarkPlugins={[remarkGfm]}>
+        {content}
+      </Markdown>
+    </article>
   );
 };
 

--- a/src/components/Portfolio.tsx
+++ b/src/components/Portfolio.tsx
@@ -1,0 +1,208 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { PROFILE } from '../config';
+
+interface GithubRepo {
+  id: number;
+  name: string;
+  description: string | null;
+  html_url: string;
+  stargazers_count: number;
+  language: string | null;
+  homepage: string | null;
+  fork: boolean;
+  updated_at: string;
+  topics?: string[];
+}
+
+const getPrimaryLanguageMix = (repos: GithubRepo[]) => {
+  const counts = repos.reduce<Record<string, number>>((acc, repo) => {
+    if (!repo.language) {
+      return acc;
+    }
+
+    acc[repo.language] = (acc[repo.language] || 0) + 1;
+    return acc;
+  }, {});
+
+  return Object.entries(counts)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 4);
+};
+
+const Portfolio: React.FC = () => {
+  const [repos, setRepos] = useState<GithubRepo[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchRepos = async () => {
+      try {
+        const response = await fetch(
+          `https://api.github.com/users/${PROFILE.githubUsername}/repos?sort=updated&per_page=100`
+        );
+
+        if (!response.ok) {
+          throw new Error(`GitHub API request failed with ${response.status}`);
+        }
+
+        const data: GithubRepo[] = await response.json();
+        setRepos(data.filter((repo) => !repo.fork));
+      } catch {
+        setError('Could not load GitHub repositories right now.');
+      }
+    };
+
+    fetchRepos();
+  }, []);
+
+  const curatedRepos = useMemo(() => {
+    const featuredByName = repos.filter((repo) => PROFILE.featuredRepoNames.includes(repo.name));
+
+    const topStarred = [...repos]
+      .sort((a, b) => b.stargazers_count - a.stargazers_count)
+      .filter((repo) => !PROFILE.featuredRepoNames.includes(repo.name))
+      .slice(0, 6);
+
+    const recent = [...repos]
+      .sort(
+        (a, b) =>
+          new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime()
+      )
+      .filter((repo) => !PROFILE.featuredRepoNames.includes(repo.name))
+      .slice(0, 6);
+
+    return {
+      featured: featuredByName,
+      topStarred,
+      recent,
+    };
+  }, [repos]);
+
+  const languageMix = useMemo(() => getPrimaryLanguageMix(repos), [repos]);
+
+  return (
+    <section className="space-y-6 text-left">
+      <header className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+        <h2 className="text-2xl font-bold">{PROFILE.name}</h2>
+        <p className="mt-2 text-gray-700 dark:text-gray-200">{PROFILE.linkedin.headline}</p>
+        <p className="mt-2 text-gray-600 dark:text-gray-300">{PROFILE.linkedin.summary}</p>
+        <p className="mt-3 text-sm text-gray-500 dark:text-gray-400">
+          {PROFILE.location} • {PROFILE.tagline}
+        </p>
+        <div className="mt-4 flex flex-wrap gap-4 text-sm">
+          <a
+            href={`https://github.com/${PROFILE.githubUsername}`}
+            className="font-semibold text-blue-600 hover:underline dark:text-blue-400"
+            target="_blank"
+            rel="noreferrer"
+          >
+            GitHub Profile
+          </a>
+          <a
+            href={PROFILE.linkedin.url}
+            className="font-semibold text-blue-600 hover:underline dark:text-blue-400"
+            target="_blank"
+            rel="noreferrer"
+          >
+            LinkedIn Profile
+          </a>
+        </div>
+
+        <div className="mt-5 flex flex-wrap gap-2">
+          {PROFILE.interests.map((interest) => (
+            <span
+              key={interest}
+              className="rounded-full bg-gray-100 px-3 py-1 text-xs font-medium text-gray-700 dark:bg-gray-700 dark:text-gray-200"
+            >
+              {interest}
+            </span>
+          ))}
+        </div>
+      </header>
+
+      {languageMix.length ? (
+        <section>
+          <h3 className="mb-3 text-xl font-semibold">Primary tech stack</h3>
+          <div className="flex flex-wrap gap-2">
+            {languageMix.map(([language, count]) => (
+              <span
+                key={language}
+                className="rounded-full border border-gray-300 px-3 py-1 text-sm dark:border-gray-600"
+              >
+                {language} ({count})
+              </span>
+            ))}
+          </div>
+        </section>
+      ) : null}
+
+      <div>
+        <h3 className="mb-3 text-xl font-semibold">Curated projects from GitHub</h3>
+        {error ? <p className="text-red-600 dark:text-red-400">{error}</p> : null}
+
+        {!error && repos.length === 0 ? (
+          <p className="text-gray-600 dark:text-gray-300">Loading repositories...</p>
+        ) : null}
+
+        {curatedRepos.featured.length ? (
+          <section className="mb-6">
+            <h4 className="mb-3 text-lg font-semibold">Featured</h4>
+            <div className="grid gap-4 md:grid-cols-2">
+              {curatedRepos.featured.map((repo) => (
+                <ProjectCard key={repo.id} repo={repo} />
+              ))}
+            </div>
+          </section>
+        ) : null}
+
+        <section className="mb-6">
+          <h4 className="mb-3 text-lg font-semibold">Top starred</h4>
+          <div className="grid gap-4 md:grid-cols-2">
+            {curatedRepos.topStarred.map((repo) => (
+              <ProjectCard key={repo.id} repo={repo} />
+            ))}
+          </div>
+        </section>
+
+        <section>
+          <h4 className="mb-3 text-lg font-semibold">Recently updated</h4>
+          <div className="grid gap-4 md:grid-cols-2">
+            {curatedRepos.recent.map((repo) => (
+              <ProjectCard key={repo.id} repo={repo} />
+            ))}
+          </div>
+        </section>
+      </div>
+    </section>
+  );
+};
+
+const ProjectCard: React.FC<{ repo: GithubRepo }> = ({ repo }) => (
+  <article className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+    <a
+      href={repo.html_url}
+      className="text-lg font-semibold text-blue-600 hover:underline dark:text-blue-400"
+      target="_blank"
+      rel="noreferrer"
+    >
+      {repo.name}
+    </a>
+    <p className="mt-2 text-sm text-gray-600 dark:text-gray-300">
+      {repo.description || 'No description provided.'}
+    </p>
+    <p className="mt-3 text-xs text-gray-500 dark:text-gray-400">
+      {repo.language || 'Unknown language'} • ⭐ {repo.stargazers_count}
+    </p>
+    {repo.homepage ? (
+      <a
+        href={repo.homepage}
+        className="mt-3 inline-block text-sm text-blue-600 hover:underline dark:text-blue-400"
+        target="_blank"
+        rel="noreferrer"
+      >
+        Live demo
+      </a>
+    ) : null}
+  </article>
+);
+
+export default Portfolio;

--- a/src/components/Portfolio.tsx
+++ b/src/components/Portfolio.tsx
@@ -11,7 +11,6 @@ interface GithubRepo {
   homepage: string | null;
   fork: boolean;
   updated_at: string;
-  topics?: string[];
 }
 
 const getPrimaryLanguageMix = (repos: GithubRepo[]) => {
@@ -26,7 +25,7 @@ const getPrimaryLanguageMix = (repos: GithubRepo[]) => {
 
   return Object.entries(counts)
     .sort((a, b) => b[1] - a[1])
-    .slice(0, 4);
+    .slice(0, 5);
 };
 
 const Portfolio: React.FC = () => {
@@ -63,10 +62,7 @@ const Portfolio: React.FC = () => {
       .slice(0, 6);
 
     const recent = [...repos]
-      .sort(
-        (a, b) =>
-          new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime()
-      )
+      .sort((a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime())
       .filter((repo) => !PROFILE.featuredRepoNames.includes(repo.name))
       .slice(0, 6);
 
@@ -119,9 +115,60 @@ const Portfolio: React.FC = () => {
         </div>
       </header>
 
+      <section className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+        <h3 className="mb-3 text-xl font-semibold">Publication</h3>
+        {PROFILE.publications.map((paper) => (
+          <article key={paper.url} className="space-y-1">
+            <a
+              href={paper.url}
+              className="text-lg font-semibold text-blue-600 hover:underline dark:text-blue-400"
+              target="_blank"
+              rel="noreferrer"
+            >
+              {paper.title}
+            </a>
+            <p className="text-sm text-gray-600 dark:text-gray-300">
+              {paper.venue} • {paper.year}
+            </p>
+          </article>
+        ))}
+      </section>
+
+      <section className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+        <h3 className="mb-3 text-xl font-semibold">Experience highlights</h3>
+        <div className="space-y-4">
+          {PROFILE.experience.map((item) => (
+            <article key={`${item.company}-${item.role}`}>
+              <h4 className="font-semibold">{item.role}</h4>
+              <p className="text-sm text-gray-600 dark:text-gray-300">
+                {item.company} • {item.period}
+              </p>
+              <ul className="mt-1 list-disc pl-5 text-sm text-gray-700 dark:text-gray-200">
+                {item.highlights.map((highlight) => (
+                  <li key={highlight}>{highlight}</li>
+                ))}
+              </ul>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+        <h3 className="mb-3 text-xl font-semibold">Education</h3>
+        <div className="space-y-3">
+          {PROFILE.education.map((item) => (
+            <article key={`${item.school}-${item.degree}`}>
+              <h4 className="font-semibold">{item.school}</h4>
+              <p className="text-sm text-gray-600 dark:text-gray-300">{item.degree}</p>
+              <p className="text-sm text-gray-500 dark:text-gray-400">{item.period}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
       {languageMix.length ? (
         <section>
-          <h3 className="mb-3 text-xl font-semibold">Primary tech stack</h3>
+          <h3 className="mb-3 text-xl font-semibold">Primary tech stack (from GitHub)</h3>
           <div className="flex flex-wrap gap-2">
             {languageMix.map(([language, count]) => (
               <span

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,14 +1,66 @@
 export const PROFILE = {
-  name: 'Omkar (OG) Shukla',
+  name: 'Anant Shukla',
   githubUsername: 'Keepingshtum',
   linkedin: {
     url: 'https://www.linkedin.com/in/ogshukla/',
-    headline: 'Builder, engineer, and lifelong tinkerer',
+    headline: 'SDE @ Amazon Web Services (AWS)',
     summary:
-      'I build practical software, explore side projects, and share ideas through writing and open-source work.',
+      'Software engineer focused on building reliable systems, practical developer tools, and thoughtful user experiences.',
   },
-  location: 'Sydney, Australia',
-  tagline: 'Shipping side projects and writing about what I learn.',
-  interests: ['AI/ML', 'Web apps', 'Developer tooling', 'Automation'],
+  location: 'San Jose, California, United States',
+  tagline: 'Engineer, mentor, and builder.',
+  interests: ['Java', 'AWS', 'Distributed systems', 'Teaching', 'Data engineering'],
   featuredRepoNames: ['Keepingshtum.github.io'],
+  experience: [
+    {
+      role: 'Software Engineer',
+      company: 'Amazon Web Services (AWS)',
+      period: 'Jul 2024 – Present',
+      highlights: ['Building internal tools and services for large-scale cloud workflows.'],
+    },
+    {
+      role: 'Teaching Associate (Instructor of Record)',
+      company: 'San José State University',
+      period: 'Aug 2023 – Jun 2024',
+      highlights: ['Taught CS146 (Data Structures and Algorithms) and CS151 (Object-Oriented Design).'],
+    },
+    {
+      role: 'Software Development Engineer Intern',
+      company: 'Amazon Web Services (AWS)',
+      period: 'May 2023 – Aug 2023',
+      highlights: ['Worked on AWS App Studio initiatives.'],
+    },
+    {
+      role: 'Associate Software Engineer',
+      company: 'Gainsight',
+      period: 'Aug 2021 – Jun 2022',
+      highlights: ['Built APIs for data ingestion and migrated customer workflows.'],
+    },
+    {
+      role: 'Data Science Intern',
+      company: 'Predicon.io',
+      period: 'Nov 2020 – Apr 2021',
+      highlights: ['Automated ETL tasks and developed monitoring dashboards.'],
+    },
+  ],
+  education: [
+    {
+      school: 'San José State University',
+      degree: 'MS, Computer Science',
+      period: 'Aug 2022 – May 2024',
+    },
+    {
+      school: 'BMS Institute of Technology and Management',
+      degree: 'BE, Computer Science and Engineering',
+      period: 'Aug 2017 – Aug 2021',
+    },
+  ],
+  publications: [
+    {
+      title: 'Published Research Paper',
+      venue: 'CSI Transactions on ICT (Springer)',
+      year: '2024',
+      url: 'https://link.springer.com/article/10.1007/s11416-024-00521-5',
+    },
+  ],
 };

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,14 @@
+export const PROFILE = {
+  name: 'Omkar (OG) Shukla',
+  githubUsername: 'Keepingshtum',
+  linkedin: {
+    url: 'https://www.linkedin.com/in/ogshukla/',
+    headline: 'Builder, engineer, and lifelong tinkerer',
+    summary:
+      'I build practical software, explore side projects, and share ideas through writing and open-source work.',
+  },
+  location: 'Sydney, Australia',
+  tagline: 'Shipping side projects and writing about what I learn.',
+  interests: ['AI/ML', 'Web apps', 'Developer tooling', 'Automation'],
+  featuredRepoNames: ['Keepingshtum.github.io'],
+};


### PR DESCRIPTION
### Motivation
- Provide a more curated portfolio experience that combines GitHub project discovery with LinkedIn-driven profile metadata so the portfolio page feels tailored and hand-curated. 
- Make profile copy configurable because direct scraping of LinkedIn is not possible in this environment, while still linking to the real LinkedIn URL. 

### Description
- Added `src/config.ts` which exposes a `PROFILE` object to centralize name, `githubUsername`, LinkedIn URL and copy, `location`, `tagline`, `interests`, and `featuredRepoNames` for easy curation. 
- Implemented a new `src/components/Portfolio.tsx` component that fetches public repos from GitHub, filters forks, computes a primary tech stack summary, and splits projects into `Featured`, `Top starred`, and `Recently updated` sections with `ProjectCard` rendering. 
- Wired the portfolio into the app shell by adding a tabbed nav in `src/App.tsx` and documented curation steps in `README.md` so non-developers can update profile copy and pinned repos without changing component code. 

### Testing
- Ran `npm run build` which completed successfully and produced the production bundle. 
- Started the dev server with `npm run dev` and captured UI screenshots with Playwright for both the blog and the curated portfolio pages (screenshots produced). 
- Attempted to fetch LinkedIn content via `curl` which returned `403 Forbidden` in this environment, so profile copy is provided via `src/config.ts` rather than scraped.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d4244fb2c83338cd4c62952289ce0)